### PR TITLE
Fix wrong folder rights for storing logs in shibboleth folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,8 @@ RUN yum -y remove wget tar unzip; yum clean all
 
 RUN useradd jetty -U -s /bin/false \
     && chown -R jetty:jetty /opt/jetty \
-    && chown -R jetty:jetty /opt/iam-jetty-base
+    && chown -R jetty:jetty /opt/iam-jetty-base \
+    && chown -R jetty:jetty /opt/shibboleth-idp/logs
 
 
 ADD container-scripts/ /opt/container-scripts/


### PR DESCRIPTION
Hello!

Would be great to include this fix, in case you would want to quickly see logs inside the container. I'm still aware that it would be an option to mount the logs folder.

Thx,
André
